### PR TITLE
Expand refs to list types to address documentation/cdk generation error

### DIFF
--- a/aws-networkfirewall-firewallpolicy/aws-networkfirewall-firewallpolicy.json
+++ b/aws-networkfirewall-firewallpolicy/aws-networkfirewall-firewallpolicy.json
@@ -37,41 +37,50 @@
       "type": "object",
       "properties": {
         "StatelessDefaultActions": {
-          "$ref": "#/definitions/StatelessActions"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
         },
         "StatelessFragmentDefaultActions": {
-          "$ref": "#/definitions/StatelessActions"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
         },
         "StatelessCustomActions": {
-          "$ref": "#/definitions/CustomActions"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/CustomAction"
+          }
         },
         "StatelessRuleGroupReferences": {
-          "$ref": "#/definitions/StatelessRuleGroupReferences"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/StatelessRuleGroupReference"
+          }
         },
         "StatefulRuleGroupReferences": {
-          "$ref": "#/definitions/StatefulRuleGroupReferences"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/StatefulRuleGroupReference"
+          }
         }
       },
       "required": [
         "StatelessDefaultActions",
         "StatelessFragmentDefaultActions"
       ]
-    },
-    "StatelessActions": {
-      "type": "array",
-      "insertionOrder": false,
-      "uniqueItems": true,
-      "items": {
-        "type": "string"
-      }
-    },
-    "CustomActions": {
-      "type": "array",
-      "insertionOrder": false,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/CustomAction"
-      }
     },
     "CustomAction": {
       "type": "object",
@@ -103,20 +112,17 @@
       "type": "object",
       "properties": {
         "Dimensions": {
-          "$ref": "#/definitions/Dimensions"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/Dimension"
+          }
         }
       },
       "required": [
         "Dimensions"
       ]
-    },
-    "Dimensions": {
-      "type": "array",
-      "insertionOrder": false,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/Dimension"
-      }
     },
     "Dimension": {
       "type": "object",
@@ -132,14 +138,6 @@
         "Value"
       ]
     },
-    "StatefulRuleGroupReferences": {
-      "type": "array",
-      "insertionOrder": false,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/StatefulRuleGroupReference"
-      }
-    },
     "StatefulRuleGroupReference": {
       "type": "object",
       "properties": {
@@ -150,14 +148,6 @@
       "required": [
         "ResourceArn"
       ]
-    },
-    "StatelessRuleGroupReferences": {
-      "type": "array",
-      "insertionOrder": false,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/StatelessRuleGroupReference"
-      }
     },
     "StatelessRuleGroupReference": {
       "type": "object",

--- a/aws-networkfirewall-loggingconfiguration/aws-networkfirewall-loggingconfiguration.json
+++ b/aws-networkfirewall-loggingconfiguration/aws-networkfirewall-loggingconfiguration.json
@@ -15,20 +15,17 @@
       "type": "object",
       "properties": {
         "LogDestinationConfigs": {
-          "$ref": "#/definitions/LogDestinationConfigs"
+          "type": "array",
+          "insertionOrder": false,
+          "items": {
+            "$ref": "#/definitions/LogDestinationConfig"
+          },
+          "minItems": 1
         }
       },
       "required": [
         "LogDestinationConfigs"
       ]
-    },
-    "LogDestinationConfigs": {
-      "type": "array",
-      "insertionOrder": false,
-      "items": {
-        "$ref": "#/definitions/LogDestinationConfig"
-      },
-      "minItems": 1
     },
     "LogDestinationConfig": {
       "type": "object",

--- a/aws-networkfirewall-rulegroup/aws-networkfirewall-rulegroup.json
+++ b/aws-networkfirewall-rulegroup/aws-networkfirewall-rulegroup.json
@@ -77,7 +77,12 @@
       "type": "object",
       "properties": {
         "Definition": {
-          "$ref": "#/definitions/VariableDefinitionList"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/VariableDefinition"
+          }
         }
       }
     },
@@ -85,16 +90,13 @@
       "type": "object",
       "properties": {
         "Definition": {
-          "$ref": "#/definitions/VariableDefinitionList"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/VariableDefinition"
+          }
         }
-      }
-    },
-    "VariableDefinitionList": {
-      "type": "array",
-      "insertionOrder": false,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/VariableDefinition"
       }
     },
     "VariableDefinition": {
@@ -112,7 +114,12 @@
           "$ref": "#/definitions/RulesSourceList"
         },
         "StatefulRules": {
-          "$ref": "#/definitions/StatefulRules"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/StatefulRule"
+          }
         },
         "StatelessRulesAndCustomActions": {
           "$ref": "#/definitions/StatelessRulesAndCustomActions"
@@ -131,7 +138,12 @@
           }
         },
         "TargetTypes": {
-          "$ref": "#/definitions/TargetTypes"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/TargetType"
+          }
         },
         "GeneratedRulesType": {
           "$ref": "#/definitions/GeneratedRulesType"
@@ -142,14 +154,6 @@
         "TargetTypes",
         "GeneratedRulesType"
       ]
-    },
-    "TargetTypes": {
-      "type": "array",
-      "insertionOrder": false,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/TargetType"
-      }
     },
     "TargetType": {
       "type": "string",
@@ -164,14 +168,6 @@
         "ALLOWLIST",
         "DENYLIST"
       ]
-    },
-    "StatefulRules": {
-      "type": "array",
-      "insertionOrder": false,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/StatefulRule"
-      }
     },
     "StatefulRule": {
       "type": "object",
@@ -188,7 +184,12 @@
           "$ref": "#/definitions/Header"
         },
         "RuleOptions": {
-          "$ref": "#/definitions/RuleOptions"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/RuleOption"
+          }
         }
       },
       "required": [
@@ -259,14 +260,6 @@
         "DestinationPort"
       ]
     },
-    "RuleOptions": {
-      "type": "array",
-      "insertionOrder": false,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/RuleOption"
-      }
-    },
     "RuleOption": {
       "type": "object",
       "properties": {
@@ -305,23 +298,25 @@
       "type": "object",
       "properties": {
         "StatelessRules": {
-          "$ref": "#/definitions/StatelessRules"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/StatelessRule"
+          }
         },
         "CustomActions": {
-          "$ref": "#/definitions/CustomActions"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/CustomAction"
+          }
         }
       },
       "required": [
         "StatelessRules"
       ]
-    },
-    "StatelessRules": {
-      "type": "array",
-      "insertionOrder": false,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/StatelessRule"
-      }
     },
     "StatelessRule": {
       "type": "object",
@@ -364,31 +359,53 @@
       "type": "object",
       "properties": {
         "Sources": {
-          "$ref": "#/definitions/Addresses"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/Address"
+          }
         },
         "Destinations": {
-          "$ref": "#/definitions/Addresses"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/Address"
+          }
         },
         "SourcePorts": {
-          "$ref": "#/definitions/PortRanges"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/PortRange"
+          }
         },
         "DestinationPorts": {
-          "$ref": "#/definitions/PortRanges"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/PortRange"
+          }
         },
         "Protocols": {
-          "$ref": "#/definitions/ProtocolNumbers"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/ProtocolNumber"
+          }
         },
         "TCPFlags": {
-          "$ref": "#/definitions/TCPFlags"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/TCPFlagField"
+          }
         }
-      }
-    },
-    "Addresses": {
-      "type": "array",
-      "insertionOrder": false,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/Address"
       }
     },
     "Address": {
@@ -404,14 +421,6 @@
       "required": [
         "AddressDefinition"
       ]
-    },
-    "PortRanges": {
-      "type": "array",
-      "insertionOrder": false,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/PortRange"
-      }
     },
     "PortRange": {
       "type": "object",
@@ -433,48 +442,34 @@
       "minimum": 0,
       "maximum": 65535
     },
-    "ProtocolNumbers": {
-      "type": "array",
-      "insertionOrder": false,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/ProtocolNumber"
-      }
-    },
     "ProtocolNumber": {
       "type": "integer",
       "minimum": 0,
       "maximum": 255
     },
-    "TCPFlags": {
-      "type": "array",
-      "insertionOrder": false,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/TCPFlagField"
-      }
-    },
     "TCPFlagField": {
       "type": "object",
       "properties": {
         "Flags": {
-          "$ref": "#/definitions/Flags"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/TCPFlag"
+          }
         },
         "Masks": {
-          "$ref": "#/definitions/Flags"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/TCPFlag"
+          }
         }
       },
       "required": [
         "Flags"
       ]
-    },
-    "Flags": {
-      "type": "array",
-      "insertionOrder": false,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/TCPFlag"
-      }
     },
     "TCPFlag": {
       "type": "string",
@@ -488,14 +483,6 @@
         "ECE",
         "CWR"
       ]
-    },
-    "CustomActions": {
-      "type": "array",
-      "insertionOrder": false,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/CustomAction"
-      }
     },
     "CustomAction": {
       "type": "object",
@@ -527,20 +514,17 @@
       "type": "object",
       "properties": {
         "Dimensions": {
-          "$ref": "#/definitions/Dimensions"
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/Dimension"
+          }
         }
       },
       "required": [
         "Dimensions"
       ]
-    },
-    "Dimensions": {
-      "type": "array",
-      "insertionOrder": false,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/Dimension"
-      }
     },
     "Dimension": {
       "type": "object",


### PR DESCRIPTION
*Description of changes:*
Looking at some other examples of resource providers and the generated documentation, it appears that a $ref to an array type generates the object with a single list property, whereas when the array type is specified at the top level, it generates an array as expected.

This PR "expands" the array references.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
