### PR TITLE
Add stabliize step to loggingConfiguration mutating apis

### DIFF
--- a/aws-networkfirewall-loggingconfiguration/src/main/java/software/amazon/networkfirewall/loggingconfiguration/CreateHandler.java
+++ b/aws-networkfirewall-loggingconfiguration/src/main/java/software/amazon/networkfirewall/loggingconfiguration/CreateHandler.java
@@ -42,10 +42,12 @@ public class CreateHandler extends BaseHandlerStd {
 
         try {
             convertTemplateToUpdateLoggingConfigurationCall(model, proxyClient, false, true);
+
+            Utils.stablize(proxyClient, model);
             return new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger);
         } catch(InvalidRequestException e){
             throw new CfnInvalidRequestException(e);
-        } catch (InternalServerErrorException | LogDestinationPermissionException | ResourceNotFoundException e) {
+        } catch (InternalServerErrorException | LogDestinationPermissionException | ResourceNotFoundException | InterruptedException e) {
             throw new CfnServiceInternalErrorException(ResourceModel.TYPE_NAME, e);
         } catch (ThrottlingException e) {
             throw new CfnThrottlingException(ResourceModel.TYPE_NAME, e);

--- a/aws-networkfirewall-loggingconfiguration/src/main/java/software/amazon/networkfirewall/loggingconfiguration/DeleteHandler.java
+++ b/aws-networkfirewall-loggingconfiguration/src/main/java/software/amazon/networkfirewall/loggingconfiguration/DeleteHandler.java
@@ -36,10 +36,12 @@ public class DeleteHandler extends BaseHandlerStd {
 
         try {
             convertTemplateToUpdateLoggingConfigurationCall(model, proxyClient, true, false);
+
+            Utils.stablize(proxyClient, model);
             return ProgressEvent.defaultSuccessHandler(null);
         } catch(InvalidRequestException e){
             throw new CfnInvalidRequestException(e);
-        } catch (InternalServerErrorException | LogDestinationPermissionException e) {
+        } catch (InternalServerErrorException | LogDestinationPermissionException | InterruptedException e) {
             throw new CfnServiceInternalErrorException(ResourceModel.TYPE_NAME, e);
         } catch (ResourceNotFoundException e) {
             throw new CfnNotFoundException(ResourceModel.TYPE_NAME, e.toString());

--- a/aws-networkfirewall-loggingconfiguration/src/main/java/software/amazon/networkfirewall/loggingconfiguration/UpdateHandler.java
+++ b/aws-networkfirewall-loggingconfiguration/src/main/java/software/amazon/networkfirewall/loggingconfiguration/UpdateHandler.java
@@ -40,10 +40,12 @@ public class UpdateHandler extends BaseHandlerStd {
 
         try {
             convertTemplateToUpdateLoggingConfigurationCall(model, proxyClient);
+
+            Utils.stablize(proxyClient, model);
             return new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger);
         } catch(InvalidRequestException e){
             throw new CfnInvalidRequestException(e);
-        } catch (InternalServerErrorException | LogDestinationPermissionException | ResourceNotFoundException e) {
+        } catch (InternalServerErrorException | LogDestinationPermissionException | ResourceNotFoundException | InterruptedException e) {
             throw new CfnServiceInternalErrorException(ResourceModel.TYPE_NAME, e);
         } catch (ThrottlingException e) {
             throw new CfnThrottlingException(ResourceModel.TYPE_NAME, e);

--- a/aws-networkfirewall-loggingconfiguration/src/test/java/software/amazon/networkfirewall/loggingconfiguration/CreateHandlerTest.java
+++ b/aws-networkfirewall-loggingconfiguration/src/test/java/software/amazon/networkfirewall/loggingconfiguration/CreateHandlerTest.java
@@ -100,7 +100,6 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(1)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(3)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -146,7 +145,6 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(2)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(3)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -170,7 +168,6 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThrows(CfnAlreadyExistsException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
 
         verify(proxyClient.client(), times(0)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(1)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -196,7 +193,6 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThrows(CfnNotFoundException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
 
         verify(proxyClient.client(), times(1)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(1)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -219,7 +215,6 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThrows(CfnInvalidRequestException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
 
         verify(proxyClient.client(), times(0)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(1)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -238,6 +233,5 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThrows(CfnInvalidRequestException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
 
         verify(proxyClient.client(), times(0)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(1)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 }

--- a/aws-networkfirewall-loggingconfiguration/src/test/java/software/amazon/networkfirewall/loggingconfiguration/DeleteHandlerTest.java
+++ b/aws-networkfirewall-loggingconfiguration/src/test/java/software/amazon/networkfirewall/loggingconfiguration/DeleteHandlerTest.java
@@ -100,7 +100,6 @@ public class DeleteHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(1)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(2)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -131,7 +130,8 @@ public class DeleteHandlerTest extends AbstractTestBase {
 
         when(proxyClient.client().describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class)))
                 .thenReturn(preCheckLoggingConfigurationResponse)
-                .thenReturn(preCheckLoggingConfigurationResponse);
+                .thenReturn(preCheckLoggingConfigurationResponse)
+                .thenReturn(finalLoggingConfigurationResponse);
 
         when(proxyClient.client().updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class)))
                 .thenReturn(updateLoggingConfigurationResponse1)
@@ -152,7 +152,6 @@ public class DeleteHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(2)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(2)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test

--- a/aws-networkfirewall-loggingconfiguration/src/test/java/software/amazon/networkfirewall/loggingconfiguration/UpdateHandlerTest.java
+++ b/aws-networkfirewall-loggingconfiguration/src/test/java/software/amazon/networkfirewall/loggingconfiguration/UpdateHandlerTest.java
@@ -112,7 +112,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(2)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(4)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -176,7 +175,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(3)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(4)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -241,7 +239,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(3)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(4)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -313,7 +310,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(4)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(4)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -371,7 +367,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(1)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(4)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -436,7 +431,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(2)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(4)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -501,7 +495,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(2)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(4)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -549,7 +542,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThrows(CfnNotFoundException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
 
         verify(proxyClient.client(), times(1)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(2)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -591,6 +583,5 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThrows(CfnInvalidRequestException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
 
         verify(proxyClient.client(), times(0)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(1)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 }

--- a/aws-networkfirewall-rulegroup/src/main/java/software/amazon/networkfirewall/rulegroup/TagUtils.java
+++ b/aws-networkfirewall-rulegroup/src/main/java/software/amazon/networkfirewall/rulegroup/TagUtils.java
@@ -25,7 +25,7 @@ public class TagUtils {
         this.tagsDiff = computeTagsDiff();
     }
 
-    // tags to add contains both new tags and exiting tag with new value
+    // tags to add contains both new tags and existing tag with new value
     public Map<String, String> tagsToAddOrUpdate() {
         Map<String, String> tagsToAdd = new HashMap<>(tagsDiff.entriesOnlyOnRight());
         // get the tags for those value has changed

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,6 +6,7 @@ phases:
         python: 3.7
     commands:
       -  pip install pre-commit cloudformation-cli-java-plugin
+      -  pip install --upgrade 'six==1.15.0'
   build:
     commands:
       - pre-commit run --all-files


### PR DESCRIPTION
*Description of changes:*
* Add "stabliize" step to loggingConfiguration mutating apis to avoid causing problems by some backend transient delays

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
