### PR TITLE
Correct the stabilize behavior that the order in logDestinationConfigs matters

### DIFF
--- a/aws-networkfirewall-loggingconfiguration/src/main/java/software/amazon/networkfirewall/loggingconfiguration/Utils.java
+++ b/aws-networkfirewall-loggingconfiguration/src/main/java/software/amazon/networkfirewall/loggingconfiguration/Utils.java
@@ -244,14 +244,17 @@ public class Utils {
             describeLoggingConfigurationResponse = client.injectCredentialsAndInvokeV2(
                     describeLoggingConfigurationRequest, client.client()::describeLoggingConfiguration);
 
-            return (model.getLoggingConfiguration() == null &&
-                    (describeLoggingConfigurationResponse.loggingConfiguration() == null ||
-                            CollectionUtils.isNullOrEmpty(
-                                    describeLoggingConfigurationResponse.loggingConfiguration().logDestinationConfigs())))
-                    || describeLoggingConfigurationResponse.loggingConfiguration()
-                    .equals(Translator.toSdkLoggingConfiguration(model.getLoggingConfiguration()));
+            return (model.getLoggingConfiguration() == null && describeLoggingConfigurationResponse.loggingConfiguration() == null)
+                    || isIdentical(model.getLoggingConfiguration().getLogDestinationConfigs(),
+                    toModelLoggingConfiguration(describeLoggingConfigurationResponse.loggingConfiguration()).getLogDestinationConfigs());
         } catch (final Exception e) {
             throw new CfnGeneralServiceException("Failed to retrieve loggingConfiguration definition.");
         }
+    }
+
+    static boolean isIdentical(final List<LogDestinationConfig> desiredLogDestinationConfigs,
+            final List<LogDestinationConfig> currentLogDestinationConfigs) {
+        return desiredLogDestinationConfigs.containsAll(currentLogDestinationConfigs)
+                && currentLogDestinationConfigs.containsAll(desiredLogDestinationConfigs);
     }
 }


### PR DESCRIPTION
*Description of changes:*
* The `stabilize` step failed to cover the case that (FLOW, ALERT) vs (ALERT, FLOW). This kind of breaks the customer experience.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
