### PR TITLE
Support Rule ordering in RuleGroup and FirewallPolicy

### DIFF
--- a/aws-networkfirewall-firewall/pom.xml
+++ b/aws-networkfirewall-firewall/pom.xml
@@ -25,12 +25,18 @@
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
             <version>[2.0.0,3.0.0)</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/networkfirewall/2.15.33 -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/networkfirewall/2.17.78 -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>networkfirewall</artifactId>
-            <version>2.15.33</version>
-         </dependency>
+            <version>2.17.78</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/utils -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>2.17.78</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-collections4 -->
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/aws-networkfirewall-firewallpolicy/.rpdk-config
+++ b/aws-networkfirewall-firewallpolicy/.rpdk-config
@@ -1,4 +1,5 @@
 {
+    "artifact_type": "RESOURCE",
     "typeName": "AWS::NetworkFirewall::FirewallPolicy",
     "language": "java",
     "runtime": "java8",
@@ -13,5 +14,6 @@
         ],
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "software.amazon.networkfirewall.firewallpolicy.HandlerWrapperExecutable"
 }

--- a/aws-networkfirewall-firewallpolicy/aws-networkfirewall-firewallpolicy.json
+++ b/aws-networkfirewall-firewallpolicy/aws-networkfirewall-firewallpolicy.json
@@ -75,6 +75,17 @@
           "items": {
             "$ref": "#/definitions/StatefulRuleGroupReference"
           }
+        },
+        "StatefulDefaultActions": {
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "StatefulEngineOptions": {
+          "$ref": "#/definitions/StatefulEngineOptions"
         }
       },
       "required": [
@@ -148,6 +159,9 @@
       "properties": {
         "ResourceArn": {
           "$ref": "#/definitions/ResourceArn"
+        },
+        "Priority": {
+          "$ref": "#/definitions/Priority"
         }
       },
       "required": [
@@ -162,9 +176,7 @@
           "$ref": "#/definitions/ResourceArn"
         },
         "Priority": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 65535
+          "$ref": "#/definitions/Priority"
         }
       },
       "required": [
@@ -172,6 +184,27 @@
         "Priority"
       ],
       "additionalProperties": false
+    },
+    "Priority": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535
+    },
+    "StatefulEngineOptions": {
+      "type": "object",
+      "properties": {
+        "RuleOrder": {
+          "$ref": "#/definitions/RuleOrder"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RuleOrder": {
+      "type": "string",
+      "enum": [
+        "DEFAULT_ACTION_ORDER",
+        "STRICT_ORDER"
+      ]
     }
   },
   "properties": {

--- a/aws-networkfirewall-firewallpolicy/pom.xml
+++ b/aws-networkfirewall-firewallpolicy/pom.xml
@@ -25,11 +25,17 @@
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
             <version>[2.0.0,3.0.0)</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/networkfirewall/2.15.33 -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/networkfirewall/2.17.78 -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>networkfirewall</artifactId>
-            <version>2.15.33</version>
+            <version>2.17.78</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/utils -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>2.17.78</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-collections4 -->
         <dependency>

--- a/aws-networkfirewall-firewallpolicy/src/main/java/software/amazon/networkfirewall/firewallpolicy/Translator.java
+++ b/aws-networkfirewall-firewallpolicy/src/main/java/software/amazon/networkfirewall/firewallpolicy/Translator.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.services.networkfirewall.model.ActionDefinition;
 import software.amazon.awssdk.services.networkfirewall.model.Dimension;
 import software.amazon.awssdk.services.networkfirewall.model.PublishMetricAction;
 import software.amazon.awssdk.services.networkfirewall.model.StatefulRuleGroupReference;
+import software.amazon.awssdk.services.networkfirewall.model.StatefulEngineOptions;
 import software.amazon.awssdk.services.networkfirewall.model.StatelessRuleGroupReference;
 import software.amazon.awssdk.services.networkfirewall.model.UpdateFirewallPolicyRequest;
 
@@ -181,7 +182,26 @@ public class Translator {
             .statelessFragmentDefaultActions(responsePolicy.statelessFragmentDefaultActions().size() != 0
                     ? translateDefaultActionFromSDK(responsePolicy.statelessFragmentDefaultActions()) : null)
             .statelessCustomActions(responsePolicy.statelessCustomActions() != null && responsePolicy.statelessCustomActions().size() != 0 ? translateCustomActionsFromSDK(responsePolicy.statelessCustomActions()): null)
+            .statefulEngineOptions(responsePolicy.statefulEngineOptions() != null ? translateStatefulEngineOptionsFromSDK(responsePolicy.statefulEngineOptions()) : null)
+            .statefulDefaultActions(responsePolicy.statefulDefaultActions() != null && responsePolicy.statefulDefaultActions().size() != 0
+                    ? translateDefaultActionFromSDK(responsePolicy.statefulDefaultActions()) : null)
             .build();
+  }
+
+  private static software.amazon.networkfirewall.firewallpolicy.StatefulEngineOptions translateStatefulEngineOptionsFromSDK(final StatefulEngineOptions statefulEngineOptions) {
+    if (statefulEngineOptions == null) {
+      return null;
+    }
+    return software.amazon.networkfirewall.firewallpolicy.StatefulEngineOptions.builder()
+            .ruleOrder(translateRuleOrderFromSdk(statefulEngineOptions.ruleOrder()))
+            .build();
+  }
+
+  private static String translateRuleOrderFromSdk(final software.amazon.awssdk.services.networkfirewall.model.RuleOrder ruleOrder) {
+    if (ruleOrder == null) {
+      return null;
+    }
+    return ruleOrder.toString();
   }
 
   private static Set<software.amazon.networkfirewall.firewallpolicy.StatefulRuleGroupReference> translateStatefulRuleGroupReferenceFromSDK (
@@ -191,7 +211,9 @@ public class Translator {
     for (StatefulRuleGroupReference reference : references) {
       software.amazon.networkfirewall.firewallpolicy.StatefulRuleGroupReference tempRef =
               software.amazon.networkfirewall.firewallpolicy.StatefulRuleGroupReference.builder()
-                      .resourceArn(reference.resourceArn()).build();
+                      .resourceArn(reference.resourceArn())
+                      .priority(reference.priority())
+                      .build();
       result.add(tempRef);
     }
     return result;
@@ -258,7 +280,12 @@ public class Translator {
                     ? translateDefaultActionToSDK(policy.getStatelessDefaultActions()) : null)
             .statelessFragmentDefaultActions(policy.getStatelessFragmentDefaultActions().size() != 0
                     ? translateDefaultActionToSDK(policy.getStatelessFragmentDefaultActions()) : null)
-            .statelessCustomActions( policy.getStatelessCustomActions() != null && policy.getStatelessCustomActions().size() != 0 ? translateCustomActionsToSDK(policy.getStatelessCustomActions()): null)
+            .statelessCustomActions(policy.getStatelessCustomActions() != null && policy.getStatelessCustomActions().size() != 0
+                    ? translateCustomActionsToSDK(policy.getStatelessCustomActions()): null)
+            .statefulEngineOptions(policy.getStatefulEngineOptions() != null
+                    ? translateStatefulEngineOptionsToSdk(policy.getStatefulEngineOptions()) : null)
+            .statefulDefaultActions(policy.getStatefulDefaultActions() != null && policy.getStatefulDefaultActions().size() != 0
+                    ? translateDefaultActionToSDK(policy.getStatefulDefaultActions()) : null)
             .build();
   }
 
@@ -268,7 +295,9 @@ public class Translator {
 
     for (software.amazon.networkfirewall.firewallpolicy.StatefulRuleGroupReference reference : references) {
       StatefulRuleGroupReference tempRef = StatefulRuleGroupReference.builder()
-                      .resourceArn(reference.getResourceArn()).build();
+                      .resourceArn(reference.getResourceArn())
+                      .priority(reference.getPriority())
+                      .build();
       result.add(tempRef);
     }
     return result;
@@ -322,5 +351,20 @@ public class Translator {
 
   private static List<String> translateDefaultActionToSDK (final Set<String> actions) {
     return new ArrayList<>(actions);
+  }
+
+  private static StatefulEngineOptions translateStatefulEngineOptionsToSdk(
+          final software.amazon.networkfirewall.firewallpolicy.StatefulEngineOptions statefulEngineOptions) {
+    return software.amazon.awssdk.services.networkfirewall.model.StatefulEngineOptions.builder()
+            .ruleOrder(translateRuleOrderToSdk(statefulEngineOptions.getRuleOrder()))
+            .build();
+  }
+
+  private static software.amazon.awssdk.services.networkfirewall.model.RuleOrder translateRuleOrderToSdk(
+          final String ruleOrder) {
+    if (ruleOrder == null) {
+      return null;
+    }
+    return software.amazon.awssdk.services.networkfirewall.model.RuleOrder.fromValue(ruleOrder);
   }
 }

--- a/aws-networkfirewall-firewallpolicy/src/test/java/software/amazon/networkfirewall/firewallpolicy/AbstractTestBase.java
+++ b/aws-networkfirewall-firewallpolicy/src/test/java/software/amazon/networkfirewall/firewallpolicy/AbstractTestBase.java
@@ -82,12 +82,14 @@ public class AbstractTestBase {
   private static final String dimension = "dimension";
   private static final String statelessAction = "aws:pass";
   private static final String fragmentStatelessAction = "aws:drop";
+  private static final String statefulAction = "aws:drop_strict";
   private static final String description = "Sample description";
   private static final String status = "ACTIVE";
   private static final String deleting = "DELETING";
   private static final String key = "key";
   private static final String key2 = "key2";
   private static final String value = "value";
+  private static final Integer priority = 101;
 
   public final static ResourceModel RESOURCE_MODEL = ResourceModel
           .builder()
@@ -119,6 +121,7 @@ public class AbstractTestBase {
                           .statefulRuleGroupReferences(
                                   software.amazon.awssdk.services.networkfirewall.model.StatefulRuleGroupReference.builder()
                                           .resourceArn(statefulRuleGroupArn)
+                                          .priority(priority)
                                           .build())
                           .statelessRuleGroupReferences(
                                   software.amazon.awssdk.services.networkfirewall.model.StatelessRuleGroupReference.builder()
@@ -137,8 +140,11 @@ public class AbstractTestBase {
                                   .build())
                           .statelessDefaultActions(statelessAction,actionName)
                           .statelessFragmentDefaultActions(fragmentStatelessAction)
-                          .build()
-                  )
+                          .statefulEngineOptions(software.amazon.awssdk.services.networkfirewall.model.StatefulEngineOptions.builder()
+                                  .ruleOrder(RuleOrder.STRICT_ORDER)
+                                  .build())
+                          .statefulDefaultActions(statefulAction)
+                          .build())
                   .tags(TagList())
                   .build();
 
@@ -181,6 +187,7 @@ public class AbstractTestBase {
                           .statefulRuleGroupReferences(
                                   software.amazon.awssdk.services.networkfirewall.model.StatefulRuleGroupReference.builder()
                                           .resourceArn(statefulRuleGroupArn)
+                                          .priority(priority)
                                           .build())
                           .statelessRuleGroupReferences(
                                   software.amazon.awssdk.services.networkfirewall.model.StatelessRuleGroupReference.builder()
@@ -199,6 +206,10 @@ public class AbstractTestBase {
                                   .build())
                           .statelessDefaultActions(statelessAction,actionName)
                           .statelessFragmentDefaultActions(fragmentStatelessAction)
+                          .statefulDefaultActions(statefulAction)
+                          .statefulEngineOptions(software.amazon.awssdk.services.networkfirewall.model.StatefulEngineOptions.builder()
+                                  .ruleOrder(RuleOrder.STRICT_ORDER)
+                                  .build())
                           .build())
                   .build();
 
@@ -221,6 +232,7 @@ public class AbstractTestBase {
                           .statefulRuleGroupReferences(
                                   software.amazon.awssdk.services.networkfirewall.model.StatefulRuleGroupReference.builder()
                                           .resourceArn(statefulRuleGroupArn)
+                                          .priority(priority)
                                           .build())
                           .statelessRuleGroupReferences(
                                   software.amazon.awssdk.services.networkfirewall.model.StatelessRuleGroupReference.builder()
@@ -239,6 +251,10 @@ public class AbstractTestBase {
                                   .build())
                           .statelessDefaultActions(statelessAction,actionName)
                           .statelessFragmentDefaultActions(fragmentStatelessAction)
+                          .statefulEngineOptions(software.amazon.awssdk.services.networkfirewall.model.StatefulEngineOptions.builder()
+                                  .ruleOrder(RuleOrder.STRICT_ORDER)
+                                  .build())
+                          .statefulDefaultActions(statefulAction)
                           .build()
                   )
                   .build();
@@ -305,12 +321,14 @@ public class AbstractTestBase {
     Set<Dimension> dimensionSet = new HashSet<>();
     Set<String> statelessDefaultAction = new HashSet<>();
     Set<String> fragmentStatelessDefaultAction = new HashSet<>();
+    Set<String> statefulDefaultAction = new HashSet<>();
     statelessReferences.add(StatelessRuleGroupReference.builder()
             .priority(1)
             .resourceArn(statelessRuleGroupArn)
             .build());
     statefulReferences.add(StatefulRuleGroupReference.builder()
             .resourceArn(statefulRuleGroupArn)
+            .priority(101)
             .build());
     dimensionSet.add(Dimension.builder()
             .value(dimension)
@@ -326,6 +344,10 @@ public class AbstractTestBase {
     statelessDefaultAction.add(statelessAction);
     statelessDefaultAction.add(actionName);
     fragmentStatelessDefaultAction.add(fragmentStatelessAction);
+    statefulDefaultAction.add(statefulAction);
+    StatefulEngineOptions statefulEngineOptions = StatefulEngineOptions.builder()
+            .ruleOrder("STRICT_ORDER")
+            .build();
 
     return FirewallPolicy.builder()
             .statefulRuleGroupReferences(statefulReferences)
@@ -333,6 +355,8 @@ public class AbstractTestBase {
             .statelessCustomActions(customAction)
             .statelessDefaultActions(statelessDefaultAction)
             .statelessFragmentDefaultActions(fragmentStatelessDefaultAction)
+            .statefulEngineOptions(statefulEngineOptions)
+            .statefulDefaultActions(statefulDefaultAction)
             .build();
   }
 

--- a/aws-networkfirewall-loggingconfiguration/.rpdk-config
+++ b/aws-networkfirewall-loggingconfiguration/.rpdk-config
@@ -1,4 +1,5 @@
 {
+    "artifact_type": "RESOURCE",
     "typeName": "AWS::NetworkFirewall::LoggingConfiguration",
     "language": "java",
     "runtime": "java8",
@@ -13,5 +14,6 @@
         ],
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "software.amazon.networkfirewall.loggingconfiguration.HandlerWrapperExecutable"
 }

--- a/aws-networkfirewall-loggingconfiguration/pom.xml
+++ b/aws-networkfirewall-loggingconfiguration/pom.xml
@@ -25,11 +25,17 @@
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
             <version>[2.0.0,3.0.0)</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/networkfirewall/2.15.33 -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/networkfirewall/2.17.78 -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>networkfirewall</artifactId>
-            <version>2.15.33</version>
+            <version>2.17.78</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/utils -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>2.17.78</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-collections4 -->
         <dependency>

--- a/aws-networkfirewall-rulegroup/aws-networkfirewall-rulegroup.json
+++ b/aws-networkfirewall-rulegroup/aws-networkfirewall-rulegroup.json
@@ -46,6 +46,9 @@
         },
         "RulesSource": {
           "$ref": "#/definitions/RulesSource"
+        },
+        "StatefulRuleOptions": {
+          "$ref": "#/definitions/StatefulRuleOptions"
         }
       },
       "required": [
@@ -559,6 +562,22 @@
         "Value"
       ],
       "additionalProperties": false
+    },
+    "StatefulRuleOptions": {
+      "type": "object",
+      "properties": {
+        "RuleOrder": {
+          "$ref": "#/definitions/RuleOrder"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RuleOrder": {
+      "type": "string",
+      "enum": [
+        "DEFAULT_ACTION_ORDER",
+        "STRICT_ORDER"
+      ]
     }
   },
   "properties": {

--- a/aws-networkfirewall-rulegroup/pom.xml
+++ b/aws-networkfirewall-rulegroup/pom.xml
@@ -25,11 +25,17 @@
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
             <version>[2.0.0,3.0.0)</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/networkfirewall/2.15.33 -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/networkfirewall/2.17.78 -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>networkfirewall</artifactId>
-            <version>2.15.33</version>
+            <version>2.17.78</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/utils -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>2.17.78</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-collections4 -->
         <dependency>

--- a/aws-networkfirewall-rulegroup/src/main/java/software/amazon/networkfirewall/rulegroup/Translator.java
+++ b/aws-networkfirewall-rulegroup/src/main/java/software/amazon/networkfirewall/rulegroup/Translator.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.services.networkfirewall.model.DescribeRuleGroupRe
 import software.amazon.awssdk.services.networkfirewall.model.ListRuleGroupsRequest;
 import software.amazon.awssdk.services.networkfirewall.model.ListRuleGroupsResponse;
 import software.amazon.awssdk.services.networkfirewall.model.RuleGroupResponse;
+import software.amazon.awssdk.services.networkfirewall.model.RuleOrder;
 import software.amazon.awssdk.services.networkfirewall.model.TagResourceRequest;
 import software.amazon.awssdk.services.networkfirewall.model.UntagResourceRequest;
 import software.amazon.awssdk.services.networkfirewall.model.UpdateRuleGroupRequest;
@@ -173,7 +174,25 @@ public class Translator {
         return software.amazon.awssdk.services.networkfirewall.model.RuleGroup.builder()
                 .rulesSource(translateRuleSourceToSdk(ruleGroup.getRulesSource()))
                 .ruleVariables(translateRuleVariablesToSdk(ruleGroup.getRuleVariables()))
+                .statefulRuleOptions(translateStatefulRuleOptionsToSdk(ruleGroup.getStatefulRuleOptions()))
                 .build();
+    }
+
+    static software.amazon.awssdk.services.networkfirewall.model.StatefulRuleOptions translateStatefulRuleOptionsToSdk(
+            final StatefulRuleOptions statefulRuleOptions) {
+        if (statefulRuleOptions == null) {
+            return null;
+        }
+        return software.amazon.awssdk.services.networkfirewall.model.StatefulRuleOptions.builder()
+                .ruleOrder(translateRuleOrderToSdk(statefulRuleOptions.getRuleOrder()))
+                .build();
+    }
+
+    static software.amazon.awssdk.services.networkfirewall.model.RuleOrder translateRuleOrderToSdk(final String ruleOrder) {
+        if (ruleOrder == null) {
+            return null;
+        }
+        return software.amazon.awssdk.services.networkfirewall.model.RuleOrder.fromValue(ruleOrder);
     }
 
     static software.amazon.awssdk.services.networkfirewall.model.RulesSource translateRuleSourceToSdk(final RulesSource rulesSource) {
@@ -535,7 +554,24 @@ public class Translator {
         return RuleGroup.builder()
                 .rulesSource(translateRuleSourceFromSdk(ruleGroup.rulesSource()))
                 .ruleVariables(translateRuleVariablesFromSdk(ruleGroup.ruleVariables()))
+                .statefulRuleOptions(translateStatefulRuleOptionsFromSdk(ruleGroup.statefulRuleOptions()))
                 .build();
+    }
+
+    static StatefulRuleOptions translateStatefulRuleOptionsFromSdk(final software.amazon.awssdk.services.networkfirewall.model.StatefulRuleOptions statefulRuleOptions) {
+        if (statefulRuleOptions == null) {
+            return null;
+        }
+        return StatefulRuleOptions.builder()
+                .ruleOrder(translateRuleOrderFromSdk(statefulRuleOptions.ruleOrder()))
+                .build();
+    }
+
+    static String translateRuleOrderFromSdk(final software.amazon.awssdk.services.networkfirewall.model.RuleOrder ruleOrder) {
+        if (ruleOrder == null) {
+            return null;
+        }
+        return ruleOrder.toString();
     }
 
     static RulesSource translateRuleSourceFromSdk(final software.amazon.awssdk.services.networkfirewall.model.RulesSource rulesSource) {

--- a/aws-networkfirewall-rulegroup/src/test/java/software/amazon/networkfirewall/rulegroup/AbstractTestBase.java
+++ b/aws-networkfirewall-rulegroup/src/test/java/software/amazon/networkfirewall/rulegroup/AbstractTestBase.java
@@ -19,6 +19,7 @@ import software.amazon.awssdk.services.networkfirewall.model.CreateRuleGroupRequ
 import software.amazon.awssdk.services.networkfirewall.model.CreateRuleGroupResponse;
 import software.amazon.awssdk.services.networkfirewall.model.DescribeRuleGroupRequest;
 import software.amazon.awssdk.services.networkfirewall.model.DescribeRuleGroupResponse;
+import software.amazon.awssdk.services.networkfirewall.model.RuleOrder;
 import software.amazon.awssdk.services.networkfirewall.model.TagResourceRequest;
 import software.amazon.awssdk.services.networkfirewall.model.TargetType;
 import software.amazon.awssdk.services.networkfirewall.model.UntagResourceRequest;
@@ -71,19 +72,20 @@ public class AbstractTestBase {
     protected static final String ACTIVE = "ACTIVE";
     protected static final String DELETING = "DELETING";
     protected static final String STATEFUL_PASS_RULE = "pass tcp 10.20.20.0/24 45400:45500 <> 10.10.10.0/24";
+    protected static final String STRICT_RULE_ORDER = "STRICT_ORDER";
 
     protected RuleGroup cfnStatelessRuleGroup1, cfnStatelessRuleGroup2, cfnStatelessRuleGroup3;
-    protected RuleGroup cfnStatefulRuleGroup1, cfnStatefulRuleGroup2, cfnStatefulRuleGroup3, cfnStatefulRuleGroup4;
+    protected RuleGroup cfnStatefulRuleGroup1, cfnStatefulRuleGroup2, cfnStatefulRuleGroup3, cfnStatefulRuleGroup4, cfnStatefulRuleGroup5;
     protected software.amazon.awssdk.services.networkfirewall.model.RuleGroup statelessSdkRuleGroup1, statelessSdkRuleGroup2, statelessSdkRuleGroup3;
     protected software.amazon.awssdk.services.networkfirewall.model.RuleGroupResponse statelessSdkRuleGroupResponseWithNoTags,
             statelessSdkRuleGroupResponseWithTags;
     protected software.amazon.awssdk.services.networkfirewall.model.RuleGroupResponse statefulSdkRuleGroupResponseWithNoTags,
             statefulSdkRuleGroupResponseWithTags;
-    protected software.amazon.awssdk.services.networkfirewall.model.RuleGroup statefulSdkRuleGroup1, statefulSdkRuleGroup2, statefulSdkRuleGroup3, statefulSdkRuleGroup4;
+    protected software.amazon.awssdk.services.networkfirewall.model.RuleGroup statefulSdkRuleGroup1, statefulSdkRuleGroup2, statefulSdkRuleGroup3, statefulSdkRuleGroup4, statefulSdkRuleGroup5;
     protected CreateRuleGroupRequest createStatelessRuleGroupRequest1, createStatelessRuleGroupRequest2, createStatelessRuleGroupRequest3;
     protected CreateRuleGroupResponse createStatelessRuleGroupResponse1, createStatelessRuleGroupResponse2, createStatelessRuleGroupResponse3;
-    protected CreateRuleGroupRequest createStatefulRuleGroupRequest1, createStatefulRuleGroupRequest2, createStatefulRuleGroupRequest3, createStatefulRuleGroupRequest4;
-    protected CreateRuleGroupResponse createStatefulRuleGroupResponse1, createStatefulRuleGroupResponse2, createStatefulRuleGroupResponse3, createStatefulRuleGroupResponse4;
+    protected CreateRuleGroupRequest createStatefulRuleGroupRequest1, createStatefulRuleGroupRequest2, createStatefulRuleGroupRequest3, createStatefulRuleGroupRequest4, createStatefulRuleGroupRequest5;
+    protected CreateRuleGroupResponse createStatefulRuleGroupResponse1, createStatefulRuleGroupResponse2, createStatefulRuleGroupResponse3, createStatefulRuleGroupResponse4, createStatefulRuleGroupResponse5;
     protected DescribeRuleGroupRequest describeCreateStatelessRuleGroupRequest1, describeCreateStatelessRuleGroupRequest2,
             describeCreateStatelessRuleGroupRequest3, describeStatelessRuleGroupRequestWithArn;
     protected DescribeRuleGroupResponse describeCreateStatelessRuleGroupResponse1, describeCreateStatelessRuleGroupResponse2, describeCreateStatelessRuleGroupResponse3;
@@ -91,9 +93,9 @@ public class AbstractTestBase {
     protected DescribeRuleGroupResponse describeUpdateStatelessRuleGroupResponse1, describeUpdateStatelessRuleGroupResponse2, describeUpdateStatelessRuleGroupResponse3;
     protected Set<Tag> statelessTags, statefulTags;
     protected DescribeRuleGroupRequest describeCreateStatefulRuleGroupRequest1, describeCreateStatefulRuleGroupRequest2, describeCreateStatefulRuleGroupRequest3,
-            describeCreateStatefulRuleGroupRequest4, describeStatefulRuleGroupRequestWithArn;
+            describeCreateStatefulRuleGroupRequest4, describeCreateStatefulRuleGroupRequest5, describeStatefulRuleGroupRequestWithArn;
     protected DescribeRuleGroupResponse describeCreateStatefulRuleGroupResponse1, describeCreateStatefulRuleGroupResponse2,
-            describeCreateStatefulRuleGroupResponse3, describeCreateStatefulRuleGroupResponse4;
+            describeCreateStatefulRuleGroupResponse3, describeCreateStatefulRuleGroupResponse4, describeCreateStatefulRuleGroupResponse5;
     protected UpdateRuleGroupRequest updateStatelessRuleGroupRequest1, updateStatelessRuleGroupRequest2, updateStatelessRuleGroupRequest3;
     protected UpdateRuleGroupResponse updateStatelessRuleGroupResponse1, updateStatelessRuleGroupResponse2, updateStatelessRuleGroupResponse3;
     protected UpdateRuleGroupRequest updateStatefulRuleGroupRequest1, updateStatefulRuleGroupRequest2, updateStatefulRuleGroupRequest3;
@@ -662,11 +664,13 @@ public class AbstractTestBase {
         cfnStatefulRuleGroup2 = createStatefulRuleGroup2();
         cfnStatefulRuleGroup3 = createStatefulRuleGroup3();
         cfnStatefulRuleGroup4 = createStatefulRuleGroup4();
+        cfnStatefulRuleGroup5 = createStatefulRuleGroup5();
 
         statefulSdkRuleGroup1 = translateToStatefulSdkRuleGroup1();
         statefulSdkRuleGroup2 = translateToStatefulSdkRuleGroup2();
         statefulSdkRuleGroup3 = translateToStatefulSdkRuleGroup3();
         statefulSdkRuleGroup4 = translateToStatefulSdkRuleGroup4();
+        statefulSdkRuleGroup5 = translateToStatefulSdkRuleGroup5();
 
         statefulTags = Collections.singleton(Tag.builder()
                 .key("rule-group")
@@ -811,6 +815,33 @@ public class AbstractTestBase {
         describeCreateStatefulRuleGroupResponse4 = DescribeRuleGroupResponse.builder()
                 .ruleGroupResponse(statefulSdkRuleGroupResponseWithTags)
                 .ruleGroup(statefulSdkRuleGroup4)
+                .updateToken(UPDATE_TOKEN)
+                .build();
+
+        // Stateful RuleGroup Request with tags - request5
+        createStatefulRuleGroupRequest5 = CreateRuleGroupRequest.builder()
+                .ruleGroup(statefulSdkRuleGroup5)
+                .capacity(CAPACITY)
+                .description(DESCRIPTION)
+                .type(STATEFUL_RULEGROUP_TYPE)
+                .ruleGroupName(STATEFUL_RULEGROUP_NAME)
+                .tags(sdkStatefulTags)
+                .build();
+
+        createStatefulRuleGroupResponse5 = CreateRuleGroupResponse.builder()
+                .ruleGroupResponse(statefulSdkRuleGroupResponseWithTags)
+                .updateToken(UPDATE_TOKEN)
+                .build();
+
+        describeCreateStatefulRuleGroupRequest5 = DescribeRuleGroupRequest.builder()
+                .ruleGroupName(STATEFUL_RULEGROUP_NAME)
+                .type(STATEFUL_RULEGROUP_TYPE)
+                .ruleGroupArn(STATEFUL_RULEGROUP_ARN)
+                .build();
+
+        describeCreateStatefulRuleGroupResponse5 = DescribeRuleGroupResponse.builder()
+                .ruleGroupResponse(statefulSdkRuleGroupResponseWithTags)
+                .ruleGroup(statefulSdkRuleGroup5)
                 .updateToken(UPDATE_TOKEN)
                 .build();
 
@@ -1007,6 +1038,56 @@ public class AbstractTestBase {
                         .ipSets(ImmutableMap.of("test", software.amazon.awssdk.services.networkfirewall.model.IPSet.builder()
                                 .definition(Collections.singleton("test-definition-1, test-definition-2"))
                                 .build()))
+                        .build())
+                .build();
+    }
+
+    private RuleGroup createStatefulRuleGroup5() {
+        return RuleGroup.builder()
+                .rulesSource(RulesSource.builder()
+                        .statefulRules(Collections.singleton(StatefulRule.builder()
+                                .action("PASS")
+                                .header(Header.builder()
+                                        .sourcePort("any")
+                                        .destinationPort("any")
+                                        .source("$HOME_NET")
+                                        .destination("$EXTERNAL_NET")
+                                        .protocol("TCP")
+                                        .direction("FORWARD")
+                                        .build())
+                                .ruleOptions(Collections.singleton(RuleOption.builder()
+                                        .keyword("sid")
+                                        .settings(Collections.singleton("100"))
+                                        .build()))
+                                .build()))
+                        .build())
+                .statefulRuleOptions(StatefulRuleOptions.builder()
+                        .ruleOrder("STRICT_ORDER")
+                        .build())
+                .build();
+    }
+
+    private software.amazon.awssdk.services.networkfirewall.model.RuleGroup translateToStatefulSdkRuleGroup5() {
+        return software.amazon.awssdk.services.networkfirewall.model.RuleGroup.builder()
+                .rulesSource(software.amazon.awssdk.services.networkfirewall.model.RulesSource.builder()
+                        .statefulRules(Collections.singleton(software.amazon.awssdk.services.networkfirewall.model.StatefulRule.builder()
+                                .action("PASS")
+                                .header(software.amazon.awssdk.services.networkfirewall.model.Header.builder()
+                                        .protocol("TCP")
+                                        .source("$HOME_NET")
+                                        .direction("FORWARD")
+                                        .sourcePort("any")
+                                        .destinationPort("any")
+                                        .destination("$EXTERNAL_NET")
+                                        .build())
+                                .ruleOptions(Collections.singleton(software.amazon.awssdk.services.networkfirewall.model.RuleOption.builder()
+                                        .settings("100")
+                                        .keyword("sid")
+                                        .build()))
+                                .build()))
+                        .build())
+                .statefulRuleOptions(software.amazon.awssdk.services.networkfirewall.model.StatefulRuleOptions.builder()
+                        .ruleOrder(RuleOrder.STRICT_ORDER)
                         .build())
                 .build();
     }

--- a/aws-networkfirewall-rulegroup/src/test/java/software/amazon/networkfirewall/rulegroup/CreateHandlerTest.java
+++ b/aws-networkfirewall-rulegroup/src/test/java/software/amazon/networkfirewall/rulegroup/CreateHandlerTest.java
@@ -388,6 +388,43 @@ public class CreateHandlerTest extends AbstractTestBase {
     }
 
     @Test
+    public void testHandleRequest_createStatefulRuleGroupSuccess5() {
+        // create request with stateful-rulegroup - with RuleOrder
+        model = ResourceModel
+                .builder()
+                .ruleGroupName(STATEFUL_RULEGROUP_NAME)
+                .ruleGroup(cfnStatefulRuleGroup5)
+                .description(DESCRIPTION)
+                .capacity(CAPACITY)
+                .type(STATEFUL_RULEGROUP_TYPE)
+                .tags(statefulTags)
+                .build();
+        request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        when(proxyClient.injectCredentialsAndInvokeV2(createStatefulRuleGroupRequest5, networkFirewallClient::createRuleGroup)).thenReturn(createStatefulRuleGroupResponse5);
+        when(proxyClient.injectCredentialsAndInvokeV2(describeCreateStatefulRuleGroupRequest5, networkFirewallClient::describeRuleGroup)).thenReturn(describeCreateStatefulRuleGroupResponse5);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        verify(proxyClient.client(), times(1)).createRuleGroup(any(CreateRuleGroupRequest.class));
+        verify(proxyClient.client(), times(2)).describeRuleGroup(any(DescribeRuleGroupRequest.class));
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel().getRuleGroupName()).isEqualTo(request.getDesiredResourceState().getRuleGroupName());
+        assertThat(response.getResourceModel().getType()).isEqualTo(request.getDesiredResourceState().getType());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+        // Validate ResourceModel
+        validateStatefulResourceModel(response.getResourceModel(), cfnStatefulRuleGroup5, statefulTags);
+    }
+
+    @Test
     public void testHandleRequest_throwsInvalidRequestException() {
         when(proxyClient.injectCredentialsAndInvokeV2(createStatelessRuleGroupRequest1, networkFirewallClient::createRuleGroup)).thenThrow(InvalidRequestException.class);
 


### PR DESCRIPTION
- RuleGroup:
     - Added StatefulRuleOptions with RuleOrder to the RuleGroup schema
    
- FirewallPolicy:
     - Added StatefulDefaultActions, Priority to StatefulRuleGroupReferences, StatefulEngineOptions with RuleOrder to the FirewallPolicy schema

- Updated the software.amazon.awssdk - networkfirewall version to include the latest SDK changes
