### PR TITLE
fix AWS::NetworkFirewall::LoggingConfiguration.LogDestination min/max constraints

### DIFF
--- a/aws-networkfirewall-loggingconfiguration/aws-networkfirewall-loggingconfiguration.json
+++ b/aws-networkfirewall-loggingconfiguration/aws-networkfirewall-loggingconfiguration.json
@@ -56,7 +56,7 @@
               "maxLength": 1024
             }
           },
-          "minItems": 1,
+          "minProperties": 1,
           "additionalProperties": false
         }
       },


### PR DESCRIPTION
@dttakata
http://json-schema.org/understanding-json-schema/reference/object.html#size
https://github.com/aws-cloudformation/cloudformation-cli/issues/414
(caught by running [`cfn validate`](https://github.com/aws-cloudformation/cloudformation-cli/pull/675))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
