### PR TITLE
fix AWS::NetworkFirewall::LoggingConfiguration.LogDestination min constraint

### DIFF
--- a/aws-networkfirewall-loggingconfiguration/aws-networkfirewall-loggingconfiguration.json
+++ b/aws-networkfirewall-loggingconfiguration/aws-networkfirewall-loggingconfiguration.json
@@ -56,7 +56,7 @@
               "maxLength": 1024
             }
           },
-          "minItems": 1,
+          "minProperties": 1,
           "additionalProperties": false
         }
       },


### PR DESCRIPTION
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-networkfirewall/pull/24

Copying the above pull request's change to a new pull request because the automatic check failed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
