### PR TITLE
Sort EndpointIds by AZ to enable resource composability

### DIFF
--- a/aws-networkfirewall-firewall/src/main/java/software/amazon/networkfirewall/firewall/Translator.java
+++ b/aws-networkfirewall-firewall/src/main/java/software/amazon/networkfirewall/firewall/Translator.java
@@ -78,7 +78,7 @@ public class Translator {
             // add AZName in the suffix of the endpointID.
             endpointIds.add(String.format("%s:%s", azName, state.attachment().endpointId()));
         }
-
+        Collections.sort(endpointIds);
         return endpointIds;
     }
 


### PR DESCRIPTION
Return EndpointIds sorted by AZ in the !GetAtt response for AWS::NetworkFirewall::Firewall see https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-networkfirewall/issues/15

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
