### PR TITLE
Sort the EndpointIds by AZ using case insensitive comparison.  

### DIFF
--- a/aws-networkfirewall-firewall/src/main/java/software/amazon/networkfirewall/firewall/Translator.java
+++ b/aws-networkfirewall-firewall/src/main/java/software/amazon/networkfirewall/firewall/Translator.java
@@ -78,6 +78,7 @@ public class Translator {
             // add AZName in the suffix of the endpointID.
             endpointIds.add(String.format("%s:%s", azName, state.attachment().endpointId()));
         }
+        endpointIds.sort(String.CASE_INSENSITIVE_ORDER);
 
         return endpointIds;
     }

--- a/aws-networkfirewall-firewall/src/test/java/software/amazon/networkfirewall/firewall/ReadHandlerTest.java
+++ b/aws-networkfirewall-firewall/src/test/java/software/amazon/networkfirewall/firewall/ReadHandlerTest.java
@@ -111,9 +111,11 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .firewallId("id").firewallArn("validarn").firewallName("firewallName").firewallPolicyArn("policyarn")
                 .vpcId("vpcId").tags(tags).build();
         final Map<String, SyncState> syncStates = ImmutableMap.of(
-            "us-west-2a", SyncState.builder().attachment(Attachment.builder().endpointId("endpoint-1").build()).build(),
             "us-west-2b", SyncState.builder().attachment(Attachment.builder().endpointId("endpoint-2").build()).build(),
-            "us-west-2c", SyncState.builder().attachment(Attachment.builder().endpointId("endpoint-3").build()).build());
+            "us-east-1b", SyncState.builder().attachment(Attachment.builder().endpointId("endpoint-2").build()).build(),
+            "us-west-2a", SyncState.builder().attachment(Attachment.builder().endpointId("endpoint-1").build()).build(),
+            "US-WEST-2c", SyncState.builder().attachment(Attachment.builder().endpointId("endpoint-3").build()).build(),
+            "US-EAST-1a", SyncState.builder().attachment(Attachment.builder().endpointId("endpoint-1").build()).build());
 
         final software.amazon.awssdk.services.networkfirewall.model.FirewallStatus status =
                 software.amazon.awssdk.services.networkfirewall.model.FirewallStatus.builder()
@@ -153,9 +155,11 @@ public class ReadHandlerTest extends AbstractTestBase {
         assertThat(model.getVpcId()).isEqualTo("vpcId");
         assertThat(model.getTags().size()).isEqualTo(3);
         assertThat(model.getTags()).isEqualTo(resourceModelTags);
-        assertThat(model.getEndpointIds().get(0)).isEqualTo("us-west-2a:endpoint-1");
-        assertThat(model.getEndpointIds().get(1)).isEqualTo("us-west-2b:endpoint-2");
-        assertThat(model.getEndpointIds().get(2)).isEqualTo("us-west-2c:endpoint-3");
+        assertThat(model.getEndpointIds().get(0)).isEqualTo("US-EAST-1a:endpoint-1");
+        assertThat(model.getEndpointIds().get(1)).isEqualTo("us-east-1b:endpoint-2");
+        assertThat(model.getEndpointIds().get(2)).isEqualTo("us-west-2a:endpoint-1");
+        assertThat(model.getEndpointIds().get(3)).isEqualTo("us-west-2b:endpoint-2");
+        assertThat(model.getEndpointIds().get(4)).isEqualTo("US-WEST-2c:endpoint-3");
 
         verify(proxyClient.client()).describeFirewall(any(DescribeFirewallRequest.class));
     }


### PR DESCRIPTION
Fixes: Issue #15

*Description of changes:*
Adds a case insensitive sort to the Endpoint Ids by the AZ.  Future proofing any possible case changes.

Updated the ReadHandlerTest to exercise the case insensitive sort and ensure that the AZs are in the proper order regardless of case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
